### PR TITLE
Add ability to prefix a message from the channel topic

### DIFF
--- a/commands/MR_Helper/mrHelper.js
+++ b/commands/MR_Helper/mrHelper.js
@@ -46,7 +46,7 @@ function parseMessageForArgs(message) {
         getBestRuns: false,
     };
 
-    const args = message.content.trim().split(/ + /g);
+    const args = message.trim().split(/ + /g);
     const cmd = args[0].slice(prefix.length).toLowerCase();
     const cmdParts = cmd.split(' ');
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { Client, Collection, Intents } = require('discord.js');
 const { loadCommands } = require('./handler/loadCommands');
+const { prepareMessage } = require('./reusables/functions');
 require('dotenv').config();
 
 const client = new Client({ 
@@ -23,8 +24,9 @@ client.on('message', async message => {
         return;
     }
 
-    const args = message.content.trim().split(/ + /g);
-    const cmd = args[0].slice(prefix.length).toLowerCase();
+    const formattedMessage = prepareMessage(message);
+    const args = formattedMessage.trim().split(/ + /g);
+    const cmd = args[0].slice(prefix.length);
     const cmdParts = cmd.split(' ');
     const cmdName = cmdParts[0];
 
@@ -34,7 +36,7 @@ client.on('message', async message => {
         return;
     }
 
-    command.execute(message, message);
+    command.execute(message, formattedMessage);
 });
 
 client.on('interactionCreate', async interaction => {

--- a/reusables/functions.js
+++ b/reusables/functions.js
@@ -66,10 +66,37 @@ const sortDungeonsBy = (dungeons, sortBy) => {
     });
 };
 
+const prepareMessage = (message) => {
+    let formattedMessage = message.content;
+    const channelPrefixes = message.channel.topic;
+    let allPrefixes = [];
+
+    if (channelPrefixes !== '') {
+        allPrefixes = channelPrefixes.split(' ');
+    }
+
+    if (!formattedMessage.includes('--realm')) {
+        const realmIndex = allPrefixes.indexOf('--realm');
+        if (realmIndex > -1) {
+            formattedMessage = `${formattedMessage} --realm ${allPrefixes[realmIndex + 1]}`;
+        }
+    }
+
+    if (!formattedMessage.includes('--region')) {
+        const regionIndex = allPrefixes.indexOf('--region');
+        if (regionIndex > -1) {
+            formattedMessage = `${formattedMessage} --region ${allPrefixes[regionIndex + 1]}`;
+        }
+    }
+
+    return formattedMessage;
+};
+
 module.exports = {
     buildTableFromJson: buildTableFromJson,
     sendStructuredResponseToUser: sendStructuredResponseToUser,
     sendEmbeddedMessage: sendEmbeddedMessage,
     getDungeonScore: getDungeonScore,
     sortDungeonsBy: sortDungeonsBy,
+    prepareMessage: prepareMessage,
 };


### PR DESCRIPTION
This helps to shorten the command, so if a channel topic is set to --realm argent-dawn --region eu

I can run just !mr-helper --name coryrules and it would then add the realm & region to the message for me.

We can still override the realm or region by saying !mr-helper --name coryrules --realm azuremyst etc.